### PR TITLE
Added support for parsing classfile version 51 (JDK7). Fix #66

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: scala
+scala:
+  - 2.10.3
+jdk:
+   - oraclejdk8
+   - oraclejdk7
+   - openjdk7
 script: sbt test

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
@@ -91,10 +91,13 @@ abstract class ClassfileParser(definitions: Definitions) {
         (in.nextByte.toInt: @switch) match {
           case CONSTANT_UTF8 | CONSTANT_UNICODE =>
             in.skip(in.nextChar)
-          case CONSTANT_CLASS | CONSTANT_STRING =>
+          case CONSTANT_CLASS | CONSTANT_STRING | CONSTANT_METHODTYPE =>
             in.skip(2)
+          case CONSTANT_METHODHANDLE =>
+            in.skip(3)
           case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF
-             | CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT =>
+             | CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT
+             | CONSTANT_INVOKEDYNAMIC =>
             in.skip(4)
           case CONSTANT_LONG | CONSTANT_DOUBLE =>
             in.skip(8)

--- a/reporter/functional-tests/src/test/java8-turning-interface-method-into-default-method/v1/A.java
+++ b/reporter/functional-tests/src/test/java8-turning-interface-method-into-default-method/v1/A.java
@@ -1,0 +1,3 @@
+public interface A {
+   public String foo();
+}

--- a/reporter/functional-tests/src/test/java8-turning-interface-method-into-default-method/v2/A.java
+++ b/reporter/functional-tests/src/test/java8-turning-interface-method-into-default-method/v2/A.java
@@ -1,0 +1,5 @@
+public interface A {
+   public default String foo() {
+      return null;
+    }
+}


### PR DESCRIPTION
I'm surprised that this issue was discovered only now, because we were missing
support for parsing JDK7 classfile (!) - so not just JDK8 ones.

The fix was to simply extend the `ClassfileParser` to consider the additional
constants that may appear in the classfile's Constant Pool.  Because the
implementation of `ClassfileParser` was copied from scalac, we simply applied
here the same fix as in
scala/scala@e78896f#diff-400a2e6482bc824c3840c10ecc43e7b0R140.
We should definitely work on removing this duplication (I'd say it's here for
historical reasons), but doing so is out of the scope of this PR.