### PR TITLE
Constructors are not inherited members. Fix #75

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -119,7 +119,8 @@ abstract class ClassInfo(val owner: PackageInfo) extends HasDeclarationName with
     (Iterator.single(this) ++ superClasses.iterator) flatMap (_.fields.get(name))
 
   def lookupClassMethods(name: String): Iterator[MemberInfo] =
-    (Iterator.single(this) ++ superClasses.iterator) flatMap (_.methods.get(name))
+    if(name == MemberInfo.ConstructorName) methods.get(name) // constructors are not inherited
+    else (Iterator.single(this) ++ superClasses.iterator) flatMap (_.methods.get(name))
 
   private def lookupInterfaceMethods(name: String): Iterator[MemberInfo] =
     allInterfaces.iterator flatMap (_.methods.get(name))

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -10,6 +10,8 @@ object MemberInfo {
   private val setterTag = "$_setter_$"
   private val setterSuffix = "_$eq"
 
+  val ConstructorName = "<init>"
+
   def maybeSetter(name: String) = name.endsWith(setterSuffix)
 }
 

--- a/reporter/functional-tests/src/test/final-class-becomes-object-nok/problems.txt
+++ b/reporter/functional-tests/src/test/final-class-becomes-object-nok/problems.txt
@@ -1,0 +1,1 @@
+method this()Unit in class A does not have a correspondent in new version


### PR DESCRIPTION
Constructors are not inherited by subclasses.  Therefore, when looking up a
method to check if it exist in the hierarchy, it's important to filter out
constructors.