### PR TITLE
Support for backward/forward binary checking

### DIFF
--- a/reporter-ui/src/main/scala/com/typesafe/tools/mima/lib/ui/widget/ProblemInfoView.scala
+++ b/reporter-ui/src/main/scala/com/typesafe/tools/mima/lib/ui/widget/ProblemInfoView.scala
@@ -113,7 +113,7 @@ class ProblemInfoView extends Component {
     def updateWith(problem: Problem) = {
       container.infoPanel.file.text = problem.fileName
       container.infoPanel.member.text = problem.referredMember
-      container.infoPanel.description.text = problem.description
+      container.infoPanel.description.text = problem.description("new")
     }
   }
 

--- a/reporter/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/reporter/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -18,7 +18,7 @@ class CollectProblemsTest {
     val mima = new MiMaLib(Config.baseClassPath)
 
     // SUT
-    val problems = mima.collectProblems(oldJarPath, newJarPath).map(_.description)
+    val problems = mima.collectProblems(oldJarPath, newJarPath).map(_.description("new"))
 
     // load oracle
     var expectedProblems = Source.fromFile(oraclePath).getLines.toList

--- a/reporter/functional-tests/src/test/case-class-concrete-becomes-abstract-nok/problems.txt
+++ b/reporter/functional-tests/src/test/case-class-concrete-becomes-abstract-nok/problems.txt
@@ -1,4 +1,4 @@
 class A was concrete; is declared abstract in new version
 method apply()java.lang.Object in object A does not have a correspondent in new version
 method apply()A in object A does not have a correspondent in new version
-the type hierarchy of object A has changed in new version. Missing types {scala.runtime.AbstractFunction0}
+the type hierarchy of object A is different in new version. Missing types {scala.runtime.AbstractFunction0}

--- a/reporter/functional-tests/src/test/class-becomes-trait-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-becomes-trait-nok/problems.txt
@@ -1,1 +1,1 @@
-declaration of class A has changed to trait A in new version; changing class to trait breaks client code
+declaration of class A is trait A in new version; changing class to trait breaks client code

--- a/reporter/functional-tests/src/test/class-changed-val-type-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-changed-val-type-in-new-version-nok/problems.txt
@@ -1,1 +1,1 @@
-method foo()Int in class A has now a different result type; was: Int, is now: java.lang.Object
+method foo()Int in class A has a different result type in new version, where it is java.lang.Object rather than Int

--- a/reporter/functional-tests/src/test/class-changed-var-type-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-changed-var-type-in-new-version-nok/problems.txt
@@ -1,2 +1,2 @@
-method foo()Int in class A has now a different result type; was: Int, is now: java.lang.Object
-method foo_=(Int)Unit in class A's type has changed; was (Int)Unit, is now: (java.lang.Object)Unit
+method foo()Int in class A has a different result type in new version, where it is java.lang.Object rather than Int
+method foo_=(Int)Unit in class A's type is different in new version, where it is (java.lang.Object)Unit instead of (Int)Unit

--- a/reporter/functional-tests/src/test/class-method-abstract-override-of-concrete-superclass-method-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-method-abstract-override-of-concrete-superclass-method-nok/problems.txt
@@ -1,1 +1,1 @@
-abstract method foo()Int in class B does not have a correspondent in old version
+in new version there is abstract method foo()Int in class B, which does not have a correspondent

--- a/reporter/functional-tests/src/test/class-method-abstract-override-of-concrete-supertrait-method-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-method-abstract-override-of-concrete-supertrait-method-nok/problems.txt
@@ -1,2 +1,2 @@
 abstract method foo()Int in class B does not have a correspondent in new version
-abstract method foo()Int in class B does not have a correspondent in old version
+in new version there is abstract method foo()Int in class B, which does not have a correspondent

--- a/reporter/functional-tests/src/test/class-method-changed-parameter-type-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-method-changed-parameter-type-nok/problems.txt
@@ -1,1 +1,1 @@
-method foo(Int)Int in class A's type has changed; was (Int)Int, is now: (java.lang.Object)java.lang.Object
+method foo(Int)Int in class A's type is different in new version, where it is (java.lang.Object)java.lang.Object instead of (Int)Int

--- a/reporter/functional-tests/src/test/class-method-changed-parameters2-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-method-changed-parameters2-nok/problems.txt
@@ -1,1 +1,1 @@
-method foo(java.lang.Object,Int)Int in class A's type has changed; was (java.lang.Object,Int)Int, is now: (Int,java.lang.Object)Int
+method foo(java.lang.Object,Int)Int in class A's type is different in new version, where it is (Int,java.lang.Object)Int instead of (java.lang.Object,Int)Int

--- a/reporter/functional-tests/src/test/class-narrowing-method-type-in-new-version-ok/problems.txt
+++ b/reporter/functional-tests/src/test/class-narrowing-method-type-in-new-version-ok/problems.txt
@@ -1,1 +1,1 @@
-method foo()Foo in class A has now a different result type; was: Foo, is now: Bar
+method foo()Foo in class A has a different result type in new version, where it is Bar rather than Foo

--- a/reporter/functional-tests/src/test/class-widening-method-type-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-widening-method-type-in-new-version-nok/problems.txt
@@ -1,1 +1,1 @@
-method foo()Int in class A has now a different result type; was: Int, is now: java.lang.Object
+method foo()Int in class A has a different result type in new version, where it is java.lang.Object rather than Int

--- a/reporter/functional-tests/src/test/trait-abstract-method-becomes-concrete2-ok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-abstract-method-becomes-concrete2-ok/problems.txt
@@ -1,1 +1,1 @@
-method foo()Int in trait A1 does not have a correspondent in old version
+method foo()Int in trait A1 is present only in new version

--- a/reporter/functional-tests/src/test/trait-abstract-val-become-concrete-ok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-abstract-val-become-concrete-ok/problems.txt
@@ -1,1 +1,1 @@
-synthetic method A$_setter_$foo_=(Int)Unit in trait A does not have a correspondent in old version
+synthetic method A$_setter_$foo_=(Int)Unit in trait A is present only in new version

--- a/reporter/functional-tests/src/test/trait-added-method-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-added-method-in-new-version-nok/problems.txt
@@ -1,1 +1,1 @@
-method bar()Int in trait A does not have a correspondent in old version
+method bar()Int in trait A is present only in new version

--- a/reporter/functional-tests/src/test/trait-added-val-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-added-val-in-new-version-nok/problems.txt
@@ -1,2 +1,2 @@
-synthetic method A$_setter_|_=(Int)Unit in trait A does not have a correspondent in old version
-method bar()Int in trait A does not have a correspondent in old version
+synthetic method A$_setter_|_=(Int)Unit in trait A is present only in new version
+method bar()Int in trait A is present only in new version

--- a/reporter/functional-tests/src/test/trait-added-var-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-added-var-in-new-version-nok/problems.txt
@@ -1,2 +1,2 @@
-method bar_=(Int)Unit in trait A does not have a correspondent in old version
-method bar()Int in trait A does not have a correspondent in old version
+method bar_=(Int)Unit in trait A is present only in new version
+method bar()Int in trait A is present only in new version

--- a/reporter/functional-tests/src/test/trait-deleting-concrete-methods-is-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-deleting-concrete-methods-is-nok/problems.txt
@@ -1,1 +1,1 @@
-classes mixing B needs to update body of method foo()Int
+in new version, classes mixing B needs to update body of method foo()Int

--- a/reporter/functional-tests/src/test/trait-method-overloading-is-ok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-method-overloading-is-ok/problems.txt
@@ -1,1 +1,1 @@
-method foo(java.lang.Object)Int in trait A does not have a correspondent in old version
+method foo(java.lang.Object)Int in trait A is present only in new version

--- a/reporter/functional-tests/src/test/trait-moving-methods-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-moving-methods-nok/problems.txt
@@ -1,2 +1,2 @@
 method foo()Int in trait A does not have a correspondent in new version
-method foo()Int in trait B does not have a correspondent in old version
+method foo()Int in trait B is present only in new version

--- a/reporter/functional-tests/src/test/trait-pushing-up-abstract-methods-is-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-pushing-up-abstract-methods-is-nok/problems.txt
@@ -1,1 +1,1 @@
-abstract method foo()Int in interface A does not have a correspondent in old version
+abstract method foo()Int in interface A is present only in new version

--- a/reporter/functional-tests/src/test/trait-pushing-up-concrete-methods-is-nok/problems.txt
+++ b/reporter/functional-tests/src/test/trait-pushing-up-concrete-methods-is-nok/problems.txt
@@ -1,2 +1,2 @@
-method foo()Int in trait A does not have a correspondent in old version
-classes mixing B needs to update body of method foo()Int
+method foo()Int in trait A is present only in new version
+in new version, classes mixing B needs to update body of method foo()Int

--- a/reporter/functional-tests/src/test/type-parameters-change-breaks-method-signature-nok/problems.txt
+++ b/reporter/functional-tests/src/test/type-parameters-change-breaks-method-signature-nok/problems.txt
@@ -1,1 +1,1 @@
-method contains(NodeImpl)Boolean in class Tree's type has changed; was (NodeImpl)Boolean, is now: (Node)Boolean
+method contains(NodeImpl)Boolean in class Tree's type is different in new version, where it is (Node)Boolean instead of (NodeImpl)Boolean

--- a/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/Analyzer.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/Analyzer.scala
@@ -81,14 +81,10 @@ private[analyze] class ClassAnalyzer extends Analyzer {
     for (newAbstrMeth <- newclazz.deferredMethods) yield {
       oldclazz.lookupMethods(newAbstrMeth.bytecodeName).find(_.sig == newAbstrMeth.sig) match {
         case None =>
-          val p = MissingMethodProblem(newAbstrMeth)
-          p.affectedVersion = Problem.ClassVersion.Old
-          Some(p)
+          Some(ReversedMissingMethodProblem(newAbstrMeth))
         case Some(found) =>
           if(found.isConcrete) {
-        	val p = AbstractMethodProblem(newAbstrMeth)
-        	p.affectedVersion = Problem.ClassVersion.Old
-        	Some(p)
+        	Some(ReversedAbstractMethodProblem(newAbstrMeth))
           }
           else
         	None
@@ -111,8 +107,7 @@ private[analyze] class TraitAnalyzer extends Analyzer {
       if (!oldclazz.lookupMethods(newmeth.bytecodeName).exists(_.sig == newmeth.sig)) {
         // this means that the method is brand new and therefore the implementation
         // has to be injected
-        val problem = MissingMethodProblem(newmeth)
-        problem.affectedVersion = Problem.ClassVersion.Old
+        val problem = ReversedMissingMethodProblem(newmeth)
         res += problem
       }
       // else a static implementation for the same method existed already, therefore
@@ -126,8 +121,7 @@ private[analyze] class TraitAnalyzer extends Analyzer {
       oldmeths find (_.sig == newmeth.sig) match {
         case Some(oldmeth) => ()
         case _ =>
-          val problem = MissingMethodProblem(newmeth)
-          problem.affectedVersion = Problem.ClassVersion.Old
+          val problem = ReversedMissingMethodProblem(newmeth)
           res += problem
       }
     }

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/Keys.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/Keys.scala
@@ -13,7 +13,13 @@ object MimaKeys {
   val previousClassfiles = TaskKey[Set[File]]("mima-previous-classfiles", "Directories or jars containing the previous class files used to test compatibility.")
   val currentClassfiles = TaskKey[File]("mima-current-classfiles", "Directory or jar containing the current class files used to test compatibility.")
   // TODO - Create a task to make a MiMaLib, is that a good idea?
-  val findBinaryIssues = TaskKey[List[(File, List[core.Problem])]]("mima-find-binary-issues", "A list of all binary incompatibilities between two files.")
+  // findBinaryIssues returns *two* lists, one for backward and one for forward problems.
+  val findBinaryIssues = TaskKey[List[(File, List[core.Problem], List[core.Problem])]]("mima-find-binary-issues", "A list of all binary incompatibilities between two files.")
   val reportBinaryIssues = TaskKey[Unit]("mima-report-binary-issues", "Logs all binary incompatibilities to the sbt console/logs.")
-  val binaryIssueFilters = SettingKey[Seq[core.ProblemFilter]]("mima-binary-issue-filters", "A list of filters to apply to binary issues found.")
+
+  val binaryIssueFilters = SettingKey[Seq[core.ProblemFilter]]("mima-binary-issue-filters", "A list of filters to apply to binary issues found. Applies both to backward and forward binary compatibility checking.")
+  val backwardIssueFilters = SettingKey[Seq[core.ProblemFilter]]("mima-backward-issue-filters", "A list of filters to apply to binary issues found. These filters only apply to backward compatibility checking.")
+  val forwardIssueFilters = SettingKey[Seq[core.ProblemFilter]]("mima-forward-issue-filters", "A list of filters to apply to binary issues found. These filters only apply to forward compatibility checking.")
+
+  val checkDirection = SettingKey[String]("mima-check-direction", "Compatibility checking direction; default is \"backward\", but can also be \"forward\" or \"both\".")
 }

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -10,21 +10,30 @@ object MimaPlugin extends Plugin {
   /** Just configures MiMa to compare previous/current classfiles.*/
   def mimaReportSettings: Seq[Setting[_]] = Seq(
     binaryIssueFilters := Nil,
+    forwardIssueFilters := Nil,
+    backwardIssueFilters := Nil,
     findBinaryIssues := {
       if (previousClassfiles.value.isEmpty) {
         streams.value.log.info(s"${name.value}: previous-artifact not set, not analyzing binary compatibility")
-        List.empty[(File, List[core.Problem])]
+        List.empty[(File, List[core.Problem], List[core.Problem])]
       }
       else {
-        previousClassfiles.value.map(previous => (previous, SbtMima.runMima(
-          previous,
-          currentClassfiles.value,
-          (fullClasspath in findBinaryIssues).value,
-          streams.value
-        )))(scala.collection.breakOut)
+        previousClassfiles.value.map { previous =>
+          val problems = SbtMima.runMima(
+            previous,
+            currentClassfiles.value,
+            (fullClasspath in findBinaryIssues).value,
+            checkDirection.value,
+            streams.value
+          )
+          (previous, problems._1, problems._2)
+        }(scala.collection.breakOut)
       }
     },
-    reportBinaryIssues <<= (findBinaryIssues, failOnProblem, binaryIssueFilters, streams, name) map SbtMima.reportErrors)
+    reportBinaryIssues <<= (findBinaryIssues, failOnProblem, binaryIssueFilters, backwardIssueFilters,
+                            forwardIssueFilters, streams, name) map { (find, fail, bin, back, forw, s, n) =>
+                              SbtMima.reportErrors(find, fail, bin ++ back, bin ++ forw, s, n)
+                           })
   /** Setup mima with default settings, applicable for most projects. */
   def mimaDefaultSettings: Seq[Setting[_]] = Seq(
     failOnProblem := true,


### PR DESCRIPTION
This pull request adds native support for backward/forward/bidirectional binary compatibility checking to MiMa. A single report is generated, with a clear explanation of which side is affected, improving the error reporting of the current Scala build, for example.
The following are included:
* Reworked the Problem set of case classes, so that mutable state is removed, and the generation of error messages is parametric with respect to the name of the affected side of the comparison. General clean up of messages, and some logic.
* Adding three new keys to the sbt plugin: ``mima-backward-issue-filters``, ``mima-forward-issue-filters``, and ``mima-check-direction``. The first two can be used to specify problem filters that only apply to the backward or the forward pass, respectively. The existing ``mima-issue-filters`` applies to both passes, and is prepended to the other two. The ``mima-check-direction`` setting can be set to "backward" (default), "forward", or "both".
* Similarly, three new command line options are added to the MiMa CLI: ``--backward-filters``, ``--forward-filters``, and ``--direction``. The meaning is similar to the three keys above.
* Updates for all of the functional test messages, reflecting the modified codebase. The new messages have been manually verified against the old ones, in order to make sure the meaning of the new messages was consistent with the old ones.

This pull request needs to be tested and reviewed before merging.