### PR TITLE
Fixed class-becomes-object-nok test. Re #75

### DIFF
--- a/reporter/functional-tests/src/test/class-becomes-object-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-becomes-object-nok/problems.txt
@@ -1,1 +1,2 @@
 class A is declared final in new version
+method this()Unit in class A does not have a correspondent in new version


### PR DESCRIPTION
When fixing #75, I've forgot to update the class-becomes-object-nok test, which
was affected by the changes made to fix the mentioned ticket.

The reason why the CI didn't fail building #75 is that a fix for #82 was only
merged *after* having merged #75.