### PR TITLE
Testing that constructor's methods aren't inherited. Re #75

### DIFF
--- a/reporter/functional-tests/src/test/class-constructor-inherited-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-constructor-inherited-nok/problems.txt
@@ -1,0 +1,1 @@
+method this(Int)Unit in class B does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/class-constructor-inherited-nok/v1/A.scala
+++ b/reporter/functional-tests/src/test/class-constructor-inherited-nok/v1/A.scala
@@ -1,0 +1,2 @@
+class A(v: Int)
+class B(v: Int) extends A(v)

--- a/reporter/functional-tests/src/test/class-constructor-inherited-nok/v2/A.scala
+++ b/reporter/functional-tests/src/test/class-constructor-inherited-nok/v2/A.scala
@@ -1,0 +1,2 @@
+class A(v: Int)
+class B extends A(1)


### PR DESCRIPTION
Constructors are special members and are not inherited. Therefore, MiMa needs to
report a binary incompatibility when a constructor is removed from a subclass.
This issue was fixed by e62ef3dc511e39fbeaa73ada5c6e58cfe7ad73a2