### PR TITLE
Enable the MiMa tests to be compiled with a separate Scala version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ jdk:
    - oraclejdk8
 script:
    - sbt test testFunctional
+   - sbt -Dmima.testScalaVersion="2.11.7" testFunctional
+   - sbt -Dmima.testScalaVersion="2.12.0-M3" testFunctional


### PR DESCRIPTION
Either change the version from the command line with the property `mima.testScalaVersion` or from
inside sbt with `set testScalaVersion in Global := "someversion"`.