### PR TITLE
Add versioned issue filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,24 @@ cache:
   - $HOME/.sbt/launchers
 
 language: scala
+
 scala:
   - 2.10.6
+
 jdk:
-   - oraclejdk8
+  - oraclejdk8
+
+env:
+  matrix:
+    - TEST_COMMAND="test"
+    - TEST_COMMAND="scripted"
+    - TEST_COMMAND="testFunctional"
+    - TEST_COMMAND="-Dmima.testScalaVersion=2.11.7 testFunctional"
+    - TEST_COMMAND="-Dmima.testScalaVersion=2.12.0-M3 testFunctional"
+
 script:
-   - sbt test testFunctional
-   - sbt -Dmima.testScalaVersion="2.11.7" testFunctional
-   - sbt -Dmima.testScalaVersion="2.12.0-M3" testFunctional
+  - sbt -J-XX:ReservedCodeCacheSize=256M $TEST_COMMAND
+
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-Xfatal-warnings")
+
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/Keys.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/Keys.scala
@@ -12,14 +12,14 @@ class BaseMimaKeys {
 
   final val mimaFailOnProblem      = settingKey[Boolean]("if true, fail the build on binary incompatibility detection.")
   final val mimaPreviousArtifacts  = settingKey[Set[ModuleID]]("Previous released artifacts used to test binary compatibility.")
-  final val mimaPreviousClassfiles = taskKey[Set[File]]("Directories or jars containing the previous class files used to test compatibility.")
+  final val mimaPreviousClassfiles = taskKey[Map[ModuleID, File]]("Directories or jars containing the previous class files used to test compatibility with a given module.")
   final val mimaCurrentClassfiles  = taskKey[File]("Directory or jar containing the current class files used to test compatibility.")
-  final val mimaFindBinaryIssues   = taskKey[List[(File, List[core.Problem], List[core.Problem])]]("A list of all backward and forward binary incompatibilities between two files.")
+  final val mimaFindBinaryIssues   = taskKey[Map[ModuleID, (List[core.Problem], List[core.Problem])]]("All backward and forward binary incompatibilities between a given module and current project.")
   final val mimaReportBinaryIssues = taskKey[Unit]("Logs all binary incompatibilities to the sbt console/logs.")
 
-  final val mimaBinaryIssueFilters   = settingKey[Seq[core.ProblemFilter]]("A list of filters to apply to binary issues found. Applies both to backward and forward binary compatibility checking.")
-  final val mimaBackwardIssueFilters = settingKey[Seq[core.ProblemFilter]]("A list of filters to apply to binary issues found. These filters only apply to backward compatibility checking.")
-  final val mimaForwardIssueFilters  = settingKey[Seq[core.ProblemFilter]]("A list of filters to apply to binary issues found. These filters only apply to forward compatibility checking.")
+  final val mimaBinaryIssueFilters   = settingKey[Seq[core.ProblemFilter]]("Filters to apply to binary issues found. Applies both to backward and forward binary compatibility checking.")
+  final val mimaBackwardIssueFilters = settingKey[Map[String, Seq[core.ProblemFilter]]]("Filters to apply to binary issues found grouped by version of a module checked against. These filters only apply to backward compatibility checking.")
+  final val mimaForwardIssueFilters  = settingKey[Map[String, Seq[core.ProblemFilter]]]("Filters to apply to binary issues found grouped by version of a module checked against. These filters only apply to forward compatibility checking.")
 
   final val mimaCheckDirection = settingKey[String]("Compatibility checking direction; default is \"backward\", but can also be \"forward\" or \"both\".")
 

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/build.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/build.sbt
@@ -1,0 +1,9 @@
+import com.typesafe.tools.mima.core._
+
+mimaPreviousArtifacts := Set("0.0.1-SNAPSHOT", "0.0.2-SNAPSHOT") map { v => organization.value %% name.value % v }
+
+val issueFilters = SettingKey[Map[String, Seq[ProblemFilter]]]("")
+issueFilters := Map(
+  "0.0.1-SNAPSHOT" -> Seq(ProblemFilters.exclude[MissingMethodProblem]("A.fooBar")),
+  "0.0.2-SNAPSHOT" -> Seq(ProblemFilters.exclude[MissingMethodProblem]("A.bar"))
+)

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/project/plugins.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % System.getProperty("plugin.version"))

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/src/main/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/src/main/A.scala
@@ -1,0 +1,3 @@
+class A {
+  def foo = 1
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/src/v1/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/src/v1/A.scala
@@ -1,0 +1,5 @@
+class A {
+  def foo = 1
+  def bar = foo
+  def fooBar = bar
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/src/v2/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/src/v2/A.scala
@@ -1,0 +1,4 @@
+class A {
+  def foo = 1
+  def bar = foo
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/test
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/backward-multiple-versions/test
@@ -1,0 +1,14 @@
+> set scalaSource in Compile := baseDirectory.value /"src" /"v1"
+> set version := s"0.0.1-SNAPSHOT"
+> publishLocal
+
+> set scalaSource in Compile := baseDirectory.value /"src" /"v2"
+> set version := s"0.0.2-SNAPSHOT"
+> publishLocal
+
+> set scalaSource in Compile := baseDirectory.value /"src" /"main"
+> set version := s"0.0.3-SNAPSHOT"
+
+-> mimaReportBinaryIssues
+> set mimaBackwardIssueFilters := issueFilters.value
+> mimaReportBinaryIssues

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/build.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/build.sbt
@@ -1,0 +1,10 @@
+import com.typesafe.tools.mima.core._
+
+mimaCheckDirection := "forward"
+mimaPreviousArtifacts := Set("0.0.1-SNAPSHOT", "0.0.2-SNAPSHOT") map { v => organization.value %% name.value % v }
+
+val issueFilters = SettingKey[Map[String, Seq[ProblemFilter]]]("")
+issueFilters := Map(
+  "0.0.1-SNAPSHOT" -> Seq(ProblemFilters.exclude[MissingMethodProblem]("A.bar")),
+  "0.0.2-SNAPSHOT" -> Seq(ProblemFilters.exclude[MissingMethodProblem]("A.fooBar"))
+)

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/project/plugins.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % System.getProperty("plugin.version"))

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/src/main/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/src/main/A.scala
@@ -1,0 +1,5 @@
+class A {
+  def foo = 1
+  def bar = foo
+  def fooBar = bar
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/src/v1/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/src/v1/A.scala
@@ -1,0 +1,3 @@
+class A {
+  def foo = 1
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/src/v2/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/src/v2/A.scala
@@ -1,0 +1,4 @@
+class A {
+  def foo = 1
+  def bar = foo
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/test
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/forward-multiple-versions/test
@@ -1,0 +1,14 @@
+> set scalaSource in Compile := baseDirectory.value /"src" /"v1"
+> set version := s"0.0.1-SNAPSHOT"
+> publishLocal
+
+> set scalaSource in Compile := baseDirectory.value /"src" /"v2"
+> set version := s"0.0.2-SNAPSHOT"
+> publishLocal
+
+> set scalaSource in Compile := baseDirectory.value /"src" /"main"
+> set version := s"0.0.3-SNAPSHOT"
+
+-> mimaReportBinaryIssues
+> set mimaForwardIssueFilters := issueFilters.value
+> mimaReportBinaryIssues

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/build.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/build.sbt
@@ -1,0 +1,8 @@
+import com.typesafe.tools.mima.core._
+
+mimaPreviousArtifacts := Set(organization.value %% name.value % "0.0.1-SNAPSHOT")
+
+val issueFilters = SettingKey[Seq[ProblemFilter]]("")
+issueFilters := Seq(
+  ProblemFilters.exclude[MissingMethodProblem]("A.bar")
+)

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/project/plugins.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % System.getProperty("plugin.version"))

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/src/main/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/src/main/A.scala
@@ -1,0 +1,3 @@
+class A {
+  def foo = 1
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/src/v1/A.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/src/v1/A.scala
@@ -1,0 +1,4 @@
+class A {
+  def foo = 1
+  def bar = foo
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/test
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/minimal/test
@@ -1,0 +1,10 @@
+> set scalaSource in Compile := baseDirectory.value /"src" /"v1"
+> set version := s"0.0.1-SNAPSHOT"
+> publishLocal
+
+> set scalaSource in Compile := baseDirectory.value /"src" /"main"
+> set version := s"0.0.2-SNAPSHOT"
+
+-> mimaReportBinaryIssues
+> set mimaBinaryIssueFilters := issueFilters.value
+> mimaReportBinaryIssues


### PR DESCRIPTION
Limiting which filters apply to which version is very useful when issue filter list becomes large and BC is being checked among multiple versions.

For example there were lots of BC issues that needed to be ignored between Akka 2.3.14 and 2.4.0. However from 2.4.0 onwards there are little or no BC issues so filtering should be kept at minimum to prevent false positive BC reports.

This change is already being used in https://github.com/akka/akka/pull/17761.

This PR also adds two scripted tests for the sbt plugin.