### PR TITLE
in build, set name of root project

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -105,7 +105,8 @@ object MimaBuild extends Build {
     project("root", file("."))
     aggregate(core, coreui, reporter, reporterui, sbtplugin)
     settings(s3Settings:_*)
-    settings(publish := (),
+    settings(name := buildName,
+             publish := (),
              publishLocal := (),
              mappings in upload <<= (assembly in reporter, assembly in reporterui, version) map { (cli, ui, v) =>
                def loc(name: String) = "migration-manager/%s/%s-%s.jar" format (v, name, v)


### PR DESCRIPTION
allowing it to default to "root" leads to this error in the
community build, after extraction:

```
[error] Fatal: multiple projects have the same artifacts visible in the same space.
[error]   root#root  from scala-records and mima, both visible in space "default"
```

perhaps dbuild ought to notice that `publish` and `publishLocal` are
`()` in the root project, but it doesn't (not dbuild 0.9.1 anyway, I
don't know about later versions).  and as far as I can see, setting
the name is harmless.

review by @dotta