### PR TITLE
Fix for AbstractMethodProblem and MissingMethodProblem matching

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
@@ -48,11 +48,13 @@ case class MissingFieldProblem(oldfld: MemberInfo) extends MemberProblem(oldfld)
   def description = affectedVersion => oldfld.fieldString + " does not have a correspondent in " + affectedVersion + " version"
 }
 
-case class MissingMethodProblem(meth: MemberInfo) extends MemberProblem(meth) {
+abstract class MissingMethodProblem(meth: MemberInfo) extends MemberProblem(meth)
+
+case class DirectMissingMethodProblem(meth: MemberInfo) extends MissingMethodProblem(meth) {
   def description = affectedVersion => (if (meth.isDeferred && !meth.owner.isTrait) "abstract " else "") + meth.methodString + " does not have a correspondent in " + affectedVersion + " version"
 }
 
-case class ReversedMissingMethodProblem(meth: MemberInfo) extends MemberProblem(meth) {
+case class ReversedMissingMethodProblem(meth: MemberInfo) extends MissingMethodProblem(meth) {
   def description = affectedVersion => (if (meth.isDeferred && !meth.owner.isTrait) "abstract " else "") + meth.methodString + " is present only in " + affectedVersion + " version"
 }
 
@@ -102,7 +104,9 @@ case class IncompatibleResultTypeProblem(oldmeth: MemberInfo, newmeth: MemberInf
 
 // In some older code within Mima, the affectedVersion could be reversed. We split AbstractMethodProblem and MissingMethodProblem
 // into two, in case the affected version is the other one, rather than the current one. (reversed if forward check).
-case class AbstractMethodProblem(newmeth: MemberInfo) extends MemberProblem(newmeth) {
+abstract class AbstractMethodProblem(newmeth: MemberInfo) extends MemberProblem(newmeth)
+
+case class DirectAbstractMethodProblem(newmeth: MemberInfo) extends AbstractMethodProblem(newmeth) {
   def description = affectedVersion => "abstract " + newmeth.methodString + " does not have a correspondent in " + affectedVersion + " version"
 }
 

--- a/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
@@ -12,7 +12,7 @@ private[analyze] abstract class BaseMethodChecker extends Checker[MemberInfo, Cl
   protected def check(method: MemberInfo, in: TraversableOnce[MemberInfo]): Option[Problem] = {
     val meths = (in filter (method.params.size == _.params.size)).toList
     if (meths.isEmpty)
-      Some(MissingMethodProblem(method))
+      Some(DirectMissingMethodProblem(method))
     else {
       meths find (_.sig == method.sig) match {
         case None =>

--- a/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodRules.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodRules.scala
@@ -29,7 +29,7 @@ private[method] object MethodRules {
     def apply(thisMember: MemberInfo, thatMember: MemberInfo): Option[Problem] = {
       // A concrete member that is made abstract entail a binary incompatibilities because client
       // code may be calling it when no concrete implementation exists
-      if (thisMember.isConcrete && thatMember.isDeferred) Some(AbstractMethodProblem(thatMember))
+      if (thisMember.isConcrete && thatMember.isDeferred) Some(DirectAbstractMethodProblem(thatMember))
       // note: Conversely, an abstract member that is made concrete does not entail incompatibilities
       // because no client code relied on it.
       else None


### PR DESCRIPTION
By using abstract classes, it is possible to preserve the
functionality of existing problem filters from previous versions.