### PR TITLE
Specify that artifact.classifier must be empty. Fixes #124

### DIFF
--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -116,8 +116,8 @@ object SbtMima {
       config <- report.configurations
       module <- config.modules
       (artifact, file) <- module.artifacts
-      // TODO - Hardcode this?
       if artifact.name == m.name
+      if artifact.classifier.isEmpty
     } yield file).headOption
     optFile getOrElse sys.error("Could not resolve previous ABI: " + m)
   }


### PR DESCRIPTION
This might not be 100% correct, if there are legitimate alternative
classifiers that are used for binary classfiles (as opposed to sources
and javadocs, which is Scala source files and Javadoc HTML files).

But this is a quick 98% fix, imo.