### PR TITLE
Synchronize ClassfileParser.parse() in attempt to prevent parsing errors in concurrent runs

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
@@ -43,7 +43,7 @@ abstract class ClassfileParser(definitions: Definitions) {
 
   def pool: ConstantPool = thepool
 
-  def parse(clazz: ClassInfo) = {
+  def parse(clazz: ClassInfo) = synchronized {
     parsed += 1
     parsedClass = clazz
     in = new BufferReader(clazz.file.toByteArray)


### PR DESCRIPTION
This tiny patch attempts to fix a thread-safety issue which causes various class file parsing errors when MiMa is run concurrently on multiple SBT subprojects (see #115 and #112).

The singleton `ClassInfo.ObjectClass` object can be used by multiple threads and it contains a `ClassFileParser` instance which is not thread-safe. I believe that synchronizing `parse()`, the only (logically) public method of `ClassFileParser`, should be a minimal fix.

For the investigation that prompted this PR, see https://github.com/typesafehub/migration-manager/issues/115#issuecomment-251879851.