### PR TITLE
Fix default value of --direction in CLI

### DIFF
--- a/reporter/src/main/scala/com/typesafe/tools/mima/cli/Main.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/cli/Main.scala
@@ -115,11 +115,12 @@ class Main(args: List[String]) extends {
 
   def run(): Int = {
     val mima = makeMima
-    val backwardProblems = (direction getOrElse Nil) match {
+    val effectiveDirection = direction.getOrElse("backwards")
+    val backwardProblems = effectiveDirection match {
       case "backward" | "backwards" | "both" => mima.collectProblems(prevfile, currentfile)
       case _ => Nil
     }
-    val forwardProblems = (direction getOrElse Nil) match {
+    val forwardProblems = effectiveDirection match {
       case "forward" | "forwards" | "both" => mima.collectProblems(currentfile, prevfile)
       case _ => Nil
     }


### PR DESCRIPTION
Since 2844ffa4, running MiMa from the CLI has been a no-op unless
the new option `--direction backwards` was provided. Only the SBT
plugin correctly used the default value.

Noticed in the SBT build of Scala on the 2.12.x branch, where
we use MiMa be calling `Main.main` from our build for some reason,
rather than using the SBT plugin directly.

This commit restores the old behaviour when that parameter is
missing, as manually tested with:

```
% sbt reporter/runMain com.typesafe.tools.mima.cli.Main --prev /Users/jz/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.0-RC1.jar --curr /Users/jz/code/scala/build/pack/lib/scala-library.jar

[info] Compiling 1 Scala source to /Users/jz/code/migration-manager/reporter/target/scala-2.10/classes...
[info] Running com.typesafe.tools.mima.cli.Main --prev /Users/jz/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.0-RC1.jar --curr /Users/jz/code/scala/build/pack/lib/scala-library.jar
Found 13 binary incompatibilities
=================================
 * method TRAIT_SETTER_SEPARATOR_STRING()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method NAME_JOIN_STRING()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method SETTER_SUFFIX_STRING()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method LAZY_LOCAL_SUFFIX_STRING()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method LOCAL_SUFFIX_STRING()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method MODULE_SUFFIX_STRING()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method MODULE_INSTANCE_NAME()java.lang.String in object
   scala.reflect.NameTransformer is declared final in current version
 * method loadFactorDenum()Int in object scala.collection.mutable.HashTable
   does not have a correspondent in current version
 * method printSizeMap()Unit in interface scala.collection.mutable.HashTable
   does not have a correspondent in current version
 * method findEntry0(java.lang.Object,Int)scala.collection.mutable.HashEntry
   in interface scala.collection.mutable.HashTable is present only in current
   version
 * method addEntry0(scala.collection.mutable.HashEntry,Int)Unit in interface
   scala.collection.mutable.HashTable is present only in current version
 * method foo()Int in interface scala.collection.mutable.HashTable is
   present only in current version
 * method isJavaAtLeast(Int)Boolean in interface scala.util.PropertiesTrait
   is present only in current version

Exception: sbt.TrapExitSecurityException thrown from the UncaughtExceptionHandler in thread "run-main-6"
java.lang.RuntimeException: Nonzero exit code: 13
    at scala.sys.package$.error(package.scala:27)
[trace] Stack trace suppressed: run last reporter/compile:runMain for the full output.
[error] (reporter/compile:runMain) Nonzero exit code: 13
[error] Total time: 2 s, completed 16/11/2016 3:36:25 PM
```

Fixes #137