### PR TITLE
Add support for Java-defined static members

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -101,8 +101,8 @@ abstract class ClassInfo(val owner: PackageInfo) extends HasDeclarationName with
   def methods: Members = { ensureLoaded(); _methods }
   override def flags: Int = _flags
 
-  /** currently not set! */
   def isScala: Boolean = { ensureLoaded(); _isScala }
+  def isScalaUnsafe: Boolean = { _isScala }
 
   def superClass_=(x: ClassInfo) = _superClass = x
   def interfaces_=(x: List[ClassInfo]) = _interfaces = x

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -23,6 +23,7 @@ class MemberInfo(val owner: ClassInfo, val bytecodeName: String, override val fl
     (if(hasSyntheticName) (if(isExtensionMethod) "extension " else "synthetic ") else "") +
     (if(isDeprecated) "deprecated " else "") + "method "+decodedName + tpe
   def methodString = shortMethodString + " in " + owner.classString
+  def memberString = if (isMethod) methodString else fieldString
   def defString = (if(isDeprecated) "@deprecated " else "") + "def " + decodedName + params.mkString("(", ",", ")") + ": " + tpe.resultType + " = "
   def applyString = decodedName + params.mkString("(", ",", ")")
 
@@ -77,6 +78,8 @@ class MemberInfo(val owner: ClassInfo, val bytecodeName: String, override val fl
   def isAccessible: Boolean = isPublic && !isSynthetic && (!hasSyntheticName || isExtensionMethod)
 
   def nonAccessible: Boolean = !isAccessible
+
+  def isStatic: Boolean = ClassfileParser.isStatic(flags)
 
   /** The name of the getter corresponding to this setter */
   private def getterName: String = {

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Members.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Members.scala
@@ -3,7 +3,7 @@ package com.typesafe.tools.mima.core
 import collection.mutable
 import collection.TraversableOnce
 
-class Members(val members: TraversableOnce[MemberInfo]) {
+class Members(members: TraversableOnce[MemberInfo]) {
 
   private val bindings = new mutable.HashMap[String, List[MemberInfo]] {
     override def default(key: String) = List()
@@ -13,6 +13,8 @@ class Members(val members: TraversableOnce[MemberInfo]) {
   def iterator: Iterator[MemberInfo] =
     for (ms <- bindings.valuesIterator; m <- ms.iterator) yield m
   def get(name: String): Iterator[MemberInfo] = bindings(name).iterator
+
+  def withoutStatic: Members = new Members(iterator.filterNot(_.isStatic))
 }
 
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
@@ -114,6 +114,13 @@ case class DirectAbstractMethodProblem(newmeth: MemberInfo) extends AbstractMeth
   def description = affectedVersion => "abstract " + newmeth.methodString + " does not have a correspondent in " + affectedVersion + " version"
 }
 
+case class StaticVirtualMemberProblem(newmeth: MemberInfo) extends AbstractMethodProblem(newmeth) {
+  def description = affectedVersion => "non-static " + newmeth.memberString + " is static in " + affectedVersion + " version"
+}
+case class VirtualStaticMemberProblem(newmeth: MemberInfo) extends AbstractMethodProblem(newmeth) {
+  def description = affectedVersion => "static " + newmeth.memberString + " is non-static in " + affectedVersion + " version"
+}
+
 case class ReversedAbstractMethodProblem(newmeth: MemberInfo) extends MemberProblem(newmeth) {
   def description = affectedVersion => "in " + affectedVersion + " version there is abstract " + newmeth.methodString + ", which does not have a correspondent"
 }

--- a/reporter/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/reporter/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -1,6 +1,9 @@
 package com.typesafe.tools.mima.lib
 
-import com.typesafe.tools.mima.core.{Config, Settings, PathResolver}
+import java.io.{BufferedInputStream, FileInputStream}
+
+import com.typesafe.tools.mima.core.{Config, PathResolver, Settings}
+
 import scala.io.Source
 import scala.tools.nsc.util._
 
@@ -21,7 +24,10 @@ class CollectProblemsTest {
     val problems = mima.collectProblems(oldJarPath, newJarPath).map(_.description("new"))
 
     // load oracle
-    var expectedProblems = Source.fromFile(oraclePath).getLines.toList
+    val inputStream = new BufferedInputStream(new FileInputStream(oraclePath))
+    var expectedProblems = try {
+      Source.fromInputStream(inputStream).getLines.toList
+    } finally inputStream.close()
 
     // diff between the oracle and the collected problems
     val unexpectedProblems = problems.filterNot(expectedProblems.contains)

--- a/reporter/functional-tests/src/test/java-class-missing-static-method-in-new-version-nok/problems.txt
+++ b/reporter/functional-tests/src/test/java-class-missing-static-method-in-new-version-nok/problems.txt
@@ -1,0 +1,1 @@
+method foo()Int in class A does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/java-class-missing-static-method-in-new-version-nok/v1/A.java
+++ b/reporter/functional-tests/src/test/java-class-missing-static-method-in-new-version-nok/v1/A.java
@@ -1,0 +1,3 @@
+public class A {
+    public static int foo() { return 42; }
+}

--- a/reporter/functional-tests/src/test/java-class-missing-static-method-in-new-version-nok/v2/A.java
+++ b/reporter/functional-tests/src/test/java-class-missing-static-method-in-new-version-nok/v2/A.java
@@ -1,0 +1,2 @@
+public class A {
+}

--- a/reporter/functional-tests/src/test/java-class-static-to-virtual-method-nok/problems.txt
+++ b/reporter/functional-tests/src/test/java-class-static-to-virtual-method-nok/problems.txt
@@ -1,0 +1,4 @@
+method foo(A)Int in class A does not have a correspondent in new version
+non-static method bar()Int in class A is static in new version
+non-static field fld in class A is static in new version
+method this()Unit in class A#Nested does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/java-class-static-to-virtual-method-nok/v1/A.java
+++ b/reporter/functional-tests/src/test/java-class-static-to-virtual-method-nok/v1/A.java
@@ -1,0 +1,6 @@
+public class A {
+    public static int fld;
+    public static int foo(A a) { return 42; }
+    public static int bar() { return 42; }
+    public static class Nested {}
+}

--- a/reporter/functional-tests/src/test/java-class-static-to-virtual-method-nok/v2/A.java
+++ b/reporter/functional-tests/src/test/java-class-static-to-virtual-method-nok/v2/A.java
@@ -1,0 +1,6 @@
+public class A {
+    public int fld;
+    public int foo() { return 42; }
+    public int bar() { return 42; }
+    public class Nested {}
+}

--- a/reporter/functional-tests/src/test/java-class-virtual-to-static-method-nok/problems.txt
+++ b/reporter/functional-tests/src/test/java-class-virtual-to-static-method-nok/problems.txt
@@ -1,0 +1,4 @@
+static field fld in class A is non-static in new version
+static method bar()Int in class A is non-static in new version
+method foo()Int in class A does not have a correspondent in new version
+method this(A)Unit in class A#Nested does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/java-class-virtual-to-static-method-nok/v1/A.java
+++ b/reporter/functional-tests/src/test/java-class-virtual-to-static-method-nok/v1/A.java
@@ -1,0 +1,6 @@
+public class A {
+    public int fld;
+    public int foo() { return 42; }
+    public int bar() { return 42; }
+    public class Nested {}
+}

--- a/reporter/functional-tests/src/test/java-class-virtual-to-static-method-nok/v2/A.java
+++ b/reporter/functional-tests/src/test/java-class-virtual-to-static-method-nok/v2/A.java
@@ -1,0 +1,6 @@
+public class A {
+    public static int fld;
+    public static int foo(A a) { return 42; }
+    public static int bar() { return 42; }
+    public static class Nested {}
+}

--- a/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/field/FieldChecker.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/field/FieldChecker.scala
@@ -15,6 +15,10 @@ private[analyze] abstract class BaseFieldChecker extends Checker[MemberInfo, Cla
           Some(InaccessibleFieldProblem(newfld))
         else if(field.sig != newfld.sig)
           Some(IncompatibleFieldTypeProblem(field, newfld))
+        else if (field.isStatic && !newfld.isStatic)
+          Some(StaticVirtualMemberProblem(field))
+        else if (!field.isStatic && newfld.isStatic)
+          Some(VirtualStaticMemberProblem(field))
         else
           None
       }

--- a/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
@@ -7,7 +7,7 @@ import com.typesafe.tools.mima.lib.analyze.Checker
 private[analyze] abstract class BaseMethodChecker extends Checker[MemberInfo, ClassInfo] {
   import MethodRules._
 
-  protected val rules = Seq(AccessModifier, FinalModifier, AbstractModifier)
+  protected val rules = Seq(AccessModifier, FinalModifier, AbstractModifier, JavaStatic)
 
   protected def check(method: MemberInfo, in: TraversableOnce[MemberInfo]): Option[Problem] = {
     val meths = (in filter (method.params.size == _.params.size)).toList

--- a/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodRules.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodRules.scala
@@ -36,4 +36,12 @@ private[method] object MethodRules {
     }
   }
 
+  object JavaStatic extends MethodRule {
+    def apply(thisMember: MemberInfo, thatMember: MemberInfo): Option[Problem] = {
+      if (thisMember.isStatic && !thatMember.isStatic) Some(StaticVirtualMemberProblem(thatMember))
+      else if (!thisMember.isStatic && thatMember.isStatic) Some(VirtualStaticMemberProblem(thatMember))
+      else None
+    }
+  }
+
 }


### PR DESCRIPTION
We can reliably/simply determine whether a class if from scalac
by the presence/absense of Scala/ScalaSig attributes. With this
knowledge, we can include static methods from non Scala classfiles
into MiMa's purview.

I've added specific code to warn about static <-> non-static changes,
which aren't binary compatible. In addition, the existing rules will
now run for these members.

In order to make this work, we also need to skip static members in
Scala classes after parsing attributes

Two other problems discovered and fixed while implementing this:

- `Members.members` is only a `TraversableOnce` which is traversed in
  the constructor. It should not be exposed as a field.

- The now inlined methods `parseFields` and `parseMethods` in
  `ClassfileParser` did not always skip the members in the class file
  even though attributes have to be parsed in all cases afterwards.

Co-Authored-By: Stefan Zeiger <szeiger@novocode.com>

