### PR TITLE
Do not skip extension methods.

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -19,7 +19,9 @@ class MemberInfo(val owner: ClassInfo, val bytecodeName: String, override val fl
   override def toString = "def " + bytecodeName + ": "+ sig
 
   def fieldString = "field "+decodedName+" in "+owner.classString
-  def shortMethodString = (if(hasSyntheticName) "synthetic " else "") + (if(isDeprecated) "deprecated " else "") + "method "+decodedName + tpe
+  def shortMethodString =
+    (if(hasSyntheticName) (if(isExtensionMethod) "extension " else "synthetic ") else "") +
+    (if(isDeprecated) "deprecated " else "") + "method "+decodedName + tpe
   def methodString = shortMethodString + " in " + owner.classString
   def defString = (if(isDeprecated) "@deprecated " else "") + "def " + decodedName + params.mkString("(", ",", ")") + ": " + tpe.resultType + " = "
   def applyString = decodedName + params.mkString("(", ",", ")")
@@ -66,7 +68,13 @@ class MemberInfo(val owner: ClassInfo, val bytecodeName: String, override val fl
 
   def hasSyntheticName: Boolean = decodedName contains '$'
 
-  def isAccessible: Boolean = isPublic && !isSynthetic && !hasSyntheticName
+  def isExtensionMethod: Boolean = {
+    var i = decodedName.length-1
+    while(i >= 0 && Character.isDigit(decodedName.charAt(i))) i -= 1
+    decodedName.substring(0, i+1).endsWith("$extension")
+  }
+
+  def isAccessible: Boolean = isPublic && !isSynthetic && (!hasSyntheticName || isExtensionMethod)
 
   def nonAccessible: Boolean = !isAccessible
 

--- a/reporter/functional-tests/src/test/value-class-added-concrete-method-nok/problems.txt
+++ b/reporter/functional-tests/src/test/value-class-added-concrete-method-nok/problems.txt
@@ -1,0 +1,1 @@
+extension method c$extension(java.lang.String,Int)Unit in object A#B does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/value-class-added-concrete-method-nok/v1/A.scala
+++ b/reporter/functional-tests/src/test/value-class-added-concrete-method-nok/v1/A.scala
@@ -1,0 +1,5 @@
+object A {
+  implicit class B(val s: String) extends scala.AnyVal {
+    def c(index: Int  ): Unit = ()
+  }
+}

--- a/reporter/functional-tests/src/test/value-class-added-concrete-method-nok/v2/A.scala
+++ b/reporter/functional-tests/src/test/value-class-added-concrete-method-nok/v2/A.scala
@@ -1,0 +1,6 @@
+object A {
+  implicit class B(val s: String) extends scala.AnyVal {
+    def c(index: Int  ): Unit = ()
+    def c(range: Range): Unit = ()
+  }
+}


### PR DESCRIPTION
They are classified as “has a synthetic name” (i.e. contains a “$”) but
regular use of these methods generates calls to the names from other
compilation units.

Fixes #135.