### PR TITLE
Treat default value getters as accessible.

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -74,7 +74,9 @@ class MemberInfo(val owner: ClassInfo, val bytecodeName: String, override val fl
     decodedName.substring(0, i+1).endsWith("$extension")
   }
 
-  def isAccessible: Boolean = isPublic && !isSynthetic && (!hasSyntheticName || isExtensionMethod)
+  def isDefaultGetter: Boolean = decodedName.contains("$default$")
+
+  def isAccessible: Boolean = isPublic && !isSynthetic && (!hasSyntheticName || isExtensionMethod || isDefaultGetter)
 
   def nonAccessible: Boolean = !isAccessible
 

--- a/reporter/functional-tests/src/test/class-method-overload-with-default-parameters-nok/problems.txt
+++ b/reporter/functional-tests/src/test/class-method-overload-with-default-parameters-nok/problems.txt
@@ -1,0 +1,2 @@
+synthetic method copy$default$2()java.lang.String in class A has a different result type in new version, where it is Int rather than java.lang.String
+synthetic method copy$default$1()Int in class A has a different result type in new version, where it is Boolean rather than Int

--- a/reporter/functional-tests/src/test/class-method-overload-with-default-parameters-nok/v1/A.scala
+++ b/reporter/functional-tests/src/test/class-method-overload-with-default-parameters-nok/v1/A.scala
@@ -1,0 +1,3 @@
+final class A {
+  def copy(x: Int = 0, y: String = "") = ()
+}

--- a/reporter/functional-tests/src/test/class-method-overload-with-default-parameters-nok/v2/A.scala
+++ b/reporter/functional-tests/src/test/class-method-overload-with-default-parameters-nok/v2/A.scala
@@ -1,0 +1,4 @@
+final class A {
+  def copy(x: Int, y: String) = ()
+  def copy(z: Boolean = true, x: Int = 0, y: String = "") = ()
+}


### PR DESCRIPTION
They are called from other compilation units and their names can change
when a new overload is added to a method with default values.

Fixes #136.