### PR TITLE
Make life easier for developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin/
 reporter/project/**
 **/eclipse.sbt
 **/.cache
+/.idea/

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -161,7 +161,8 @@ object MimaBuild {
   										.dependsOn(core, reporter)
 
   // select all testN directories.
-  val bases = (file("reporter") / "functional-tests" / "src" / "test") * (DirectoryFilter)
+  val bases = (file("reporter") / "functional-tests" / "src" / "test") *
+    (DirectoryFilter && new SimpleFileFilter(_.list.contains("problems.txt")))
 
   // make the Project for each discovered directory
   lazy val tests = bases.get map testProject


### PR DESCRIPTION
- Ignore .idea dirs (there’s already a bunch of Eclipse-specific
  patterns in .gitignore)

- Require that test dirs contain a “problems.txt” file. When switching
  between branches with different tests, you’re left with empty dirs
  under reporter/src/test. They used to be picked up as tests (which
  subsequently failed because they are not).