### PR TITLE
Do not skip classes with symbolic names in objects

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
@@ -76,7 +76,7 @@ abstract class PackageInfo(val owner: PackageInfo) {
     def isAccessible(clazz: ClassInfo, prefix: Set[ClassInfo]) = {
       def isReachable = {
         if (clazz.isSynthetic) false
-        else if (prefix.isEmpty) clazz.isTopLevel && !clazz.bytecodeName.contains("$$")
+        else if (prefix.isEmpty) clazz.isTopLevel && !clazz.decodedName.contains("$$")
         else prefix.exists(_.innerClasses contains clazz.bytecodeName)
       }
       clazz.isPublic && !clazz.isLocalClass && isReachable

--- a/reporter/functional-tests/src/test/removing-method-with-special-characters-from-inner-class-nok/problems.txt
+++ b/reporter/functional-tests/src/test/removing-method-with-special-characters-from-inner-class-nok/problems.txt
@@ -1,0 +1,2 @@
+abstract method f()Int in class foo.A#B does not have a correspondent in new version
+abstract method f()Int in class foo.A#< does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/removing-method-with-special-characters-from-inner-class-nok/v1/A.scala
+++ b/reporter/functional-tests/src/test/removing-method-with-special-characters-from-inner-class-nok/v1/A.scala
@@ -1,0 +1,12 @@
+package foo
+
+// See https://github.com/typesafehub/migration-manager/issues/158
+// `<` would be filtered out, therefore not reporting the missing method
+object A {
+  abstract class < {
+    def f: Int
+  }
+  abstract class B {
+    def f: Int
+  }
+}

--- a/reporter/functional-tests/src/test/removing-method-with-special-characters-from-inner-class-nok/v2/A.scala
+++ b/reporter/functional-tests/src/test/removing-method-with-special-characters-from-inner-class-nok/v2/A.scala
@@ -1,0 +1,6 @@
+package foo
+
+object A {
+  abstract class <
+  abstract class B
+}


### PR DESCRIPTION
We used to skip all classes whose bytecode name contains “$$” under the
assumption that those would be names with synthetic components like
“$$anonfun” but these names can also occur when a class name starting
with a symbolic character is nested inside an object (e.g. “A$$less” is
a class named “<“ inside an “object A”). Instead we need to look at the
decoded names. They still contain synthetic components such as
“$$anonfun” verbatim but no accidental “$$” sequences.

Fixes #158.