### PR TITLE
Filters from file support in sbt plugin

### DIFF
--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
@@ -1,0 +1,34 @@
+package com.typesafe.tools.mima.core
+
+import org.scalatest._
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class ProblemFiltersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
+  import ProblemFiltersSpec._
+
+  val filters = Table(
+    ("filter", "problem", "realProblem"),
+    (ProblemFilters.exclude[Problem]("impl.Http"), problem("impl.Http"),  false),
+    (ProblemFilters.exclude[Problem]("impl.Http"), problem("impl.Http2"), true),
+    (ProblemFilters.exclude[Problem]("impl.*"),    problem("impl.Http"),  false),
+    (ProblemFilters.exclude[Problem]("impl.*"),    problem("impl2.Http"), true),
+    (ProblemFilters.exclude[Problem]("a$Impl*"),   problem("a$Impl$B"),   false),
+    (ProblemFilters.exclude[Problem]("a$Impl*"),   problem("a2$Impl$B"),  true)
+  )
+
+  "problem filters" should {
+    "filter problems" in {
+      forAll (filters) { (filter, problem, realProblem) =>
+        filter(problem) shouldBe realProblem
+      }
+    }
+  }
+
+}
+
+object ProblemFiltersSpec {
+  def problem(name: String) = new TemplateProblem(NoClass) {
+    override def description: (String) => String = ???
+    override def matchName: Some[String] = Some(name)
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -77,6 +77,7 @@ object Dependencies {
   import BuildSettings._
 
   val typesafeConfig = "com.typesafe" % "config" % "1.0.0"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
 
 }
 
@@ -104,7 +105,10 @@ object MimaBuild {
                 buildInfoObject  := "BuildInfo"
                 )
            )
-    settings(libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    settings(libraryDependencies ++= Seq(
+               "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+               scalatest
+             ),
              name := buildName + "-core")
     settings(sonatypePublishSettings:_*)
   )

--- a/reporter/functional-tests/src/it/scala-reflect-2-10/test.conf
+++ b/reporter/functional-tests/src/it/scala-reflect-2-10/test.conf
@@ -4,10 +4,11 @@ v1 = "2.10.0"
 v2 = "2.10.6"
 
 filter {
-  packages = [
-    "scala.reflect.internal"
-  ]
   problems=[
+    {
+      matchName="scala.reflect.internal.*"
+      problemName=Problem
+    },
     {
       matchName="scala.reflect.macros.Attachments$NonemptyAttachments"
       problemName=MissingClassProblem

--- a/reporter/functional-tests/src/it/scala-reflect-2-11/test.conf
+++ b/reporter/functional-tests/src/it/scala-reflect-2-11/test.conf
@@ -4,10 +4,11 @@ v1 = "2.11.0"
 v2 = "2.11.8"
 
 filter {
-  packages = [
-    "scala.reflect.internal"
-  ]
   problems=[
+    {
+      matchName="scala.reflect.internal.*"
+      problemName=Problem
+    },
     {
       matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree"
       problemName=MissingMethodProblem

--- a/reporter/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/reporter/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -26,7 +26,7 @@ class CollectProblemsTest {
     val allProblems = mima.collectProblems(oldJarPath, newJarPath)
 
     val problems = (if(filterPath ne null) {
-      val fallback = ConfigFactory.parseString("filter { problems = []\npackages=[] }")
+      val fallback = ConfigFactory.parseString("filter { problems = [] }")
       val config = ConfigFactory.parseFile(new File(filterPath)).withFallback(fallback).resolve()
       val filters = ProblemFiltersConfig.parseProblemFilters(config)
       allProblems.filter(p => filters.forall(_.apply(p)))

--- a/reporter/src/main/scala/com/typesafe/tools/mima/cli/ProblemFiltersConfig.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/cli/ProblemFiltersConfig.scala
@@ -7,7 +7,6 @@ import scala.collection.JavaConverters._
 
 object ProblemFiltersConfig {
   private val filterProblemsPath = "filter.problems"
-  private val filterPackagesPath = "filter.packages"
   private val problemNameKey = "problemName"
   private val matchNameKey = "matchName"
 
@@ -20,16 +19,11 @@ object ProblemFiltersConfig {
    */
   def parseProblemFilters(config: Config): Seq[ProblemFilter] = {
     val filters = config.getConfigList(filterProblemsPath).asScala.toSeq
-    val individualFilter = for (problemConfig <- filters) yield {
+    for (problemConfig <- filters) yield {
       val problemClassName = problemConfig.getString(problemNameKey)
       val matchName = problemConfig.getString(matchNameKey)
       ProblemFilters.exclude(problemClassName, matchName)
     }
-    val packages = config.getStringList(filterPackagesPath).asScala.toSeq
-    val packageFilter = for (pack <- packages) yield {
-      ProblemFilters.excludePackage(pack)
-    }
-    individualFilter ++ packageFilter
   }
 
   /**


### PR DESCRIPTION
Filter file is a different format from the one that is supported by the CLI. A different format was chosen partly because it is less verbose and partly because such format is already used in akka-http.

Builds on top #172

Fixes #170