### PR TITLE
Get new instance of mutable mima instance

### DIFF
--- a/reporter/src/main/scala/com/typesafe/tools/mima/cli/Main.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/cli/Main.scala
@@ -114,14 +114,14 @@ class Main(args: List[String]) extends {
   def parseFilters(os:Option[String]) = os.toSeq.map(filePath => loadFilters(new File(filePath))).flatten
 
   def run(): Int = {
-    val mima = makeMima
     val effectiveDirection = direction.getOrElse("backwards")
+    // MiMaLib collects problems to a mutable buffer, therefore we need a new instance every time
     val backwardProblems = effectiveDirection match {
-      case "backward" | "backwards" | "both" => mima.collectProblems(prevfile, currentfile)
+      case "backward" | "backwards" | "both" => makeMima.collectProblems(prevfile, currentfile)
       case _ => Nil
     }
     val forwardProblems = effectiveDirection match {
-      case "forward" | "forwards" | "both" => mima.collectProblems(currentfile, prevfile)
+      case "forward" | "forwards" | "both" => makeMima.collectProblems(currentfile, prevfile)
       case _ => Nil
     }
     val bothFilters = parseFilters(problemFilters)

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -32,13 +32,13 @@ object SbtMima {
       the first for backward compatibility checking, and the second for forward checking. */
   def runMima(prev: File, curr: File, cp: sbt.Keys.Classpath,
               dir: String, s: TaskStreams): (List[core.Problem], List[core.Problem]) = {
-    val mimaLib = makeMima(cp, s)
+    // MiMaLib collects problems to a mutable buffer, therefore we need a new instance every time
     (dir match {
-       case "backward" | "backwards" | "both" => mimaLib.collectProblems(prev.getAbsolutePath, curr.getAbsolutePath)
+       case "backward" | "backwards" | "both" => makeMima(cp, s).collectProblems(prev.getAbsolutePath, curr.getAbsolutePath)
        case _ => Nil
      },
      dir match {
-       case "forward" | "forwards" | "both" => mimaLib.collectProblems(curr.getAbsolutePath, prev.getAbsolutePath)
+       case "forward" | "forwards" | "both" => makeMima(cp, s).collectProblems(curr.getAbsolutePath, prev.getAbsolutePath)
        case _ => Nil
      })
   }


### PR DESCRIPTION
MiMaLib accumulates problems in a [mutable list buffer](https://github.com/typesafehub/migration-manager/blob/f147e625781d3ddfafb3897120874dce0993ec20/reporter/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala#L37). Therefore we need to create a new MiMaLib instance between checking for backward and forward BC problems.

This change is required to be able to check for BC probems in `both` directions (like in Scala).