### PR TITLE
Fix package name for nested packages, in 2.12

### DIFF
--- a/core/src/main/scala-2.12/com/typesafe/tools/mima/core/package.scala
+++ b/core/src/main/scala-2.12/com/typesafe/tools/mima/core/package.scala
@@ -28,7 +28,7 @@ package object core {
     cp.classesIn(pkg).flatMap(_.binary).toIndexedSeq
 
   def packagesFrom(cp: CompilerClassPath, owner: ConcretePackageInfo): Seq[(String, PackageInfo)] =
-    (cp.packagesIn(owner.pkg) map (p => p.name -> new ConcretePackageInfo(owner, cp, owner.pkg + p.name, owner.defs)))
+    (cp.packagesIn(owner.pkg) map (p => p.name.stripPrefix(owner.pkg + ".") -> new ConcretePackageInfo(owner, cp, p.name, owner.defs)))
 
   def definitionsTargetPackages(pkg: PackageInfo, cp: CompilerClassPath, defs: Definitions): Seq[(String, PackageInfo)] =
     cp.packagesIn(ClassPath.RootPackage).map(p => p.name -> new ConcretePackageInfo(pkg, cp, p.name, defs))

--- a/reporter/functional-tests/src/test/package-nested-with-breaking-change-is-nok/problems.txt
+++ b/reporter/functional-tests/src/test/package-nested-with-breaking-change-is-nok/problems.txt
@@ -1,0 +1,5 @@
+method toHex(Array[Byte])java.lang.String in class A does not have a correspondent in new version
+method toHex(Array[Byte])java.lang.String in class p.A does not have a correspondent in new version
+method toHex(Array[Byte])java.lang.String in class p.q.A does not have a correspondent in new version
+method toHex(Array[Byte])java.lang.String in class p.q.r.A does not have a correspondent in new version
+method toHex(Array[Byte])java.lang.String in class p.q.r.s.A does not have a correspondent in new version

--- a/reporter/functional-tests/src/test/package-nested-with-breaking-change-is-nok/v1/A.scala
+++ b/reporter/functional-tests/src/test/package-nested-with-breaking-change-is-nok/v1/A.scala
@@ -1,0 +1,27 @@
+class A {
+  def toHex(bytes: Array[Byte]): String = ???
+}
+
+package p {
+  class A {
+    def toHex(bytes: Array[Byte]): String = ???
+  }
+}
+
+package p.q {
+  class A {
+    def toHex(bytes: Array[Byte]): String = ???
+  }
+}
+
+package p.q.r {
+  class A {
+    def toHex(bytes: Array[Byte]): String = ???
+  }
+}
+
+package p.q.r.s {
+  class A {
+    def toHex(bytes: Array[Byte]): String = ???
+  }
+}

--- a/reporter/functional-tests/src/test/package-nested-with-breaking-change-is-nok/v2/A.scala
+++ b/reporter/functional-tests/src/test/package-nested-with-breaking-change-is-nok/v2/A.scala
@@ -1,0 +1,27 @@
+class A {
+  def toHex(bytes: Array[Byte], b: Boolean): String = ???
+}
+
+package p {
+  class A {
+    def toHex(bytes: Array[Byte], b: Boolean): String = ???
+  }
+}
+
+package p.q {
+  class A {
+    def toHex(bytes: Array[Byte], b: Boolean): String = ???
+  }
+}
+
+package p.q.r {
+  class A {
+    def toHex(bytes: Array[Byte], b: Boolean): String = ???
+  }
+}
+
+package p.q.r.s {
+  class A {
+    def toHex(bytes: Array[Byte], b: Boolean): String = ???
+  }
+}


### PR DESCRIPTION
This was causing no class to be found (!!) because it would define the
package as "pp.q" instead of "p.q".