### PR TITLE
Version updates and changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,15 @@ env:
     - TEST_COMMAND="test"
     - TEST_COMMAND="scripted"
     - TEST_COMMAND="testFunctional"
-    - TEST_COMMAND="-Dmima.testScalaVersion=2.11.8 testFunctional"
-    - TEST_COMMAND="-Dmima.testScalaVersion=2.12.1 testFunctional"
+    - TEST_COMMAND="-Dmima.testScalaVersion=2.11.11 testFunctional"
+    - TEST_COMMAND="-Dmima.testScalaVersion=2.12.3 testFunctional"
     - TEST_COMMAND="it:test"
     - TEST_COMMAND="mimaReportBinaryIssues"
-    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.2 ^^1.0.0-RC2 test"
-    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.2 ^^1.0.0-RC2 scripted"
-    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.2 testFunctional"
-    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.2 it:test"
-    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.2 ^^1.0.0-RC2 mimaReportBinaryIssues"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.3 ^^1.0.0-RC3 test"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.3 ^^1.0.0-RC3 scripted"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.3 testFunctional"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.3 it:test"
+    - TEST_COMMAND="-Dmima.buildScalaVersion=2.12.3 ^^1.0.0-RC3 mimaReportBinaryIssues"
 
 script:
   - sbt $TEST_COMMAND

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -112,7 +112,10 @@ object MimaBuild {
              publish := (),
              publishLocal := (),
              publishSigned := (),
-             crossSbtVersions := List("0.13.16-RC1", "1.0.0-RC2"),
+             sbtVersion in Global := "0.13.13", // Should be ThisBuild, but ^^ uses Global (incorrectly)
+             inThisBuild(Seq(
+               crossSbtVersions := List("0.13.13", "1.0.0-RC3")
+             )),
              testScalaVersion in Global :=  sys.props.getOrElse("mima.testScalaVersion", scalaVersion.value)
     )
     enablePlugins(GitVersioning)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-RC1
+sbt.version=0.13.16

--- a/sbtplugin/src/main/scala-sbt-0.13/compat.scala
+++ b/sbtplugin/src/main/scala-sbt-0.13/compat.scala
@@ -6,6 +6,10 @@ package sbt
 
 object compat {
   val scalaModuleInfo = SettingKey[Option[librarymanagement.ScalaModuleInfo]]("ivyScala")
+
+  implicit class ModuleIdOps(val _m: ModuleID) extends AnyVal {
+    def withName(n: String): ModuleID = _m copy (name = n)
+  }
 }
 
 package librarymanagement {


### PR DESCRIPTION
+ upgrade to Scala 2.11.11
+ upgrade to Scala 2.12.3 (refs #191)
+ upgrade to sbt 0.13.16/1.0.0-RC3
+ cross-build against 0.13.13 instead of 0.13.16 (fixes #183)